### PR TITLE
Group @eslint/* with eslint deps and ignore @eslint/js@10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,12 @@ updates:
       ignore:
           # ESLint 10 ecosystem isn't ready: eslint-plugin-react@7 peers
           # only ^9.7, eslint-plugin-jsx-a11y@6 peers only ^9, and
-          # eslint-plugin-react-hooks@5 peers only ^9. Re-evaluate when
-          # those plugins ship v10-compatible majors.
+          # eslint-plugin-react-hooks@5 peers only ^9. @eslint/js@10
+          # peers eslint@^10 so it can't install on its own either.
+          # Re-evaluate when those plugins ship v10-compatible majors.
           - dependency-name: 'eslint'
+            versions: ['10.x']
+          - dependency-name: '@eslint/js'
             versions: ['10.x']
           - dependency-name: 'eslint-plugin-react-hooks'
             versions: ['6.x']
@@ -60,6 +63,7 @@ updates:
               patterns:
                   - 'eslint'
                   - 'eslint-*'
+                  - '@eslint/*'
                   - '@typescript-eslint/*'
           vite:
               patterns:


### PR DESCRIPTION
## Summary
- @eslint/js lives in the `@eslint/` scope, so the `eslint-*` glob in the eslint group config didn't match it. That let dependabot send #114 — a standalone `@eslint/js@10` bump that fails `npm ci` with ERESOLVE because `@eslint/js@10` peers `eslint@^10` and the project is on `eslint@9`.
- Adds `@eslint/*` to the eslint group's patterns so future scoped bumps get grouped with eslint-plugin updates.
- Adds a `10.x` ignore for `@eslint/js`, mirroring the existing `eslint@10.x` ignore.
- Closes #114.

## Test plan
- [ ] CI green on this PR (only a config change; no code surface)
- [ ] Confirm dependabot stops re-filing `@eslint/js@10` bumps on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)